### PR TITLE
Pass non-trailingslashed url instead.

### DIFF
--- a/src/DetectSitemapsURLs.php
+++ b/src/DetectSitemapsURLs.php
@@ -115,7 +115,7 @@ class DetectSitemapsURLs {
                 if ( $status_code === 200 ) {
                     $sitemap_urls[] = $sitemap;
 
-                    $parser->parse( $wp_site_url . $sitemap );
+                    $parser->parse( $base_uri . $sitemap );
 
                     $extract_sitemaps = $parser->getSitemaps();
 


### PR DESCRIPTION
## Why make this change?

- The SitemapParser instance gives an error as follows:
- ```PHP Fatal error:  Uncaught WP2StaticGuzzleHttp\Exception\ClientException: Client error: `GET http://localhos
t.localdomain//wp-sitemap.xml` resulted in a `404 Not Found` ```
- YoastSEO no longer redirects double slashed urls.
- The Client instance receives a single slashed url (e.g. http://example.com/wp-sitemap.xml), but the SitemapParser instance receives a double slashed url (.g. http://example.com//wp-sitemap.xml). 

## What/How changed?

- Passes the variable of `$base_url`, non-trailingslashed url instead of the `$wp_site_url` of trailingslashed url, to the SitemapParser instance.

## Where will this change affect?

- When kick the SSG via GUI and CLI

