### PR TITLE
Fix wrong sitemap URI when crawling multisite with subdirectory

### DIFF
--- a/src/DetectSitemapsURLs.php
+++ b/src/DetectSitemapsURLs.php
@@ -70,7 +70,7 @@ class DetectSitemapsURLs {
             }
         }
 
-        $request = new Request( 'GET', '/robots.txt', $headers );
+        $request = new Request( 'GET', $base_uri . '/robots.txt', $headers );
 
         $response = $client->send( $request );
 
@@ -81,7 +81,7 @@ class DetectSitemapsURLs {
 
             // if robots exists, parse for possible sitemaps
             if ( $robots_exists ) {
-                $parser->parseRecursive( $wp_site_url . 'robots.txt' );
+                $parser->parseRecursive( $base_uri . '/robots.txt' );
                 $sitemaps = $parser->getSitemaps();
             }
 
@@ -106,7 +106,7 @@ class DetectSitemapsURLs {
                     $sitemap
                 );
 
-                $request = new Request( 'GET', $sitemap, $headers );
+                $request = new Request( 'GET', $base_uri . $sitemap, $headers );
 
                 $response = $client->send( $request );
 

--- a/src/DetectSitemapsURLs.php
+++ b/src/DetectSitemapsURLs.php
@@ -115,7 +115,7 @@ class DetectSitemapsURLs {
                 if ( $status_code === 200 ) {
                     $sitemap_urls[] = $sitemap;
 
-                    $parser->parse( $wp_site_url . $sitemap );
+                    $parser->parse( $base_uri . $sitemap );
 
                     $extract_sitemaps = $parser->getSitemaps();
 

--- a/wp2static.php
+++ b/wp2static.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP2Static
  * Plugin URI:  https://wp2static.com
  * Description: Static site generator functionality for WordPress.
- * Version:     7.1.8-dev
+ * Version:     7.1.8-dev-np
  * Author:      WP2Static
  * Author URI:  https://wp2static.com
  * Text Domain: wp2static


### PR DESCRIPTION
## Why make this change?

- Requesting URI of a multisite site placed in a subdirectory can be wrong , since the `base_uri` of the Client instance is always the root URL.

## What/How changed?

- Pass a full URI to the Request instance and the SitemapParser instance.

## Where will this change affect?

- The `detect` step of the SSG.

