### PR TITLE
Improve Crawling Performance

### DIFF
--- a/src/CrawlCache.php
+++ b/src/CrawlCache.php
@@ -145,8 +145,6 @@ class CrawlCache {
     public static function rmUrl( string $url ) : void {
         global $wpdb;
 
-        $hashed_url = md5( $url );
-
         $table_name = $wpdb->prefix . 'wp2static_crawl_cache';
 
         $wpdb->delete(

--- a/src/CrawlQueue.php
+++ b/src/CrawlQueue.php
@@ -95,6 +95,19 @@ class CrawlQueue {
         $wpdb->query( "DELETE FROM $table_name WHERE ID IN($ids)" );
     }
 
+    public static function rmUrl( string $url ) : void {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'wp2static_urls';
+
+        $wpdb->delete(
+            $table_name,
+            [
+                'hashed_url' => md5( $url ),
+            ]
+        );
+    }
+
     /**
      *  Get total crawlable URLs
      *

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -160,6 +160,8 @@ class Crawler {
                     if ( $status_code === 404 ) {
                         WsLog::l( '404 for URL ' . $root_relative_path );
                         CrawlCache::rmUrl( $root_relative_path );
+                        // Delete crawl queue to prevent crawling not found urls forever.
+                        CrawlQueue::rmUrl( $root_relative_path );
                         $crawled_contents = null;
                         $is_cacheable = false;
                     } elseif ( in_array( $status_code, WP2STATIC_REDIRECT_CODES ) ) {

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -173,7 +173,7 @@ class Crawler {
                                 $prefix = trailingslashit( $deleting_path_prefix );
                                 $suffix = ltrim( $root_relative_path, '/' );
                                 $full_path = $prefix . $dir . $suffix;
-                                if ( is_link( $full_path ) ) {
+                                if ( file_exists( $full_path ) ) {
                                     unlink( $full_path );
                                 }
                             },

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -162,17 +162,23 @@ class Crawler {
                         CrawlCache::rmUrl( $root_relative_path );
                         // Delete crawl queue to prevent crawling not found urls forever.
                         CrawlQueue::rmUrl( $root_relative_path );
-                        // Delete previously generated files under the directories both the crawled and the processed.
-                        $deleting_path_prefix =
-                            apply_filters('wp2static_deleting_path_prefix', SiteInfo::getPath('uploads'));
-                        array_map( function( $dir ) use ( $deleting_path_prefix, $root_relative_path ) {
-                            $prefix = trailingslashit($deleting_path_prefix);
-                            $suffix = ltrim($root_relative_path, '/');
-                            $full_path = $prefix . $dir . $suffix;
-                            if( is_link( $full_path ) ){
-                                unlink($full_path);
-                            }
-                        }, ['wp2static-crawled-site/', 'wp2static-processed-site/']);
+                        // Delete previously generated files under the directories,
+                        // both the crawled and the processed.
+                        $deleting_path_prefix = apply_filters(
+                            'wp2static_deleting_path_prefix',
+                            SiteInfo::getPath( 'uploads' )
+                        );
+                        array_map(
+                            function( $dir ) use ( $deleting_path_prefix, $root_relative_path ) {
+                                $prefix = trailingslashit( $deleting_path_prefix );
+                                $suffix = ltrim( $root_relative_path, '/' );
+                                $full_path = $prefix . $dir . $suffix;
+                                if ( is_link( $full_path ) ) {
+                                    unlink( $full_path );
+                                }
+                            },
+                            [ 'wp2static-crawled-site/', 'wp2static-processed-site/' ]
+                        );
                         $crawled_contents = null;
                         $is_cacheable = false;
                     } elseif ( in_array( $status_code, WP2STATIC_REDIRECT_CODES ) ) {
@@ -214,7 +220,7 @@ class Crawler {
 
                     $this->crawled++;
 
-                    if ( $crawled_contents && $write_contents) {
+                    if ( $crawled_contents && $write_contents ) {
                         // do some magic here - naive: if URL ends in /, save to /index.html
                         // TODO: will need love for example, XML files
                         // check content type, serve .xml/rss, etc instead
@@ -228,7 +234,7 @@ class Crawler {
                         }
                     }
 
-                    if( $is_cacheable ) {
+                    if ( $is_cacheable ) {
                         CrawlCache::addUrl(
                             $root_relative_path,
                             $page_hash,

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -162,6 +162,17 @@ class Crawler {
                         CrawlCache::rmUrl( $root_relative_path );
                         // Delete crawl queue to prevent crawling not found urls forever.
                         CrawlQueue::rmUrl( $root_relative_path );
+                        // Delete previously generated files under the directories both the crawled and the processed.
+                        $deleting_path_prefix =
+                            apply_filters('wp2static_deleting_path_prefix', SiteInfo::getPath('uploads'));
+                        array_map( function( $dir ) use ( $deleting_path_prefix, $root_relative_path ) {
+                            $prefix = trailingslashit($deleting_path_prefix);
+                            $suffix = ltrim($root_relative_path, '/');
+                            $full_path = $prefix . $dir . $suffix;
+                            if( is_link( $full_path ) ){
+                                unlink($full_path);
+                            }
+                        }, ['wp2static-crawled-site/', 'wp2static-processed-site/']);
                         $crawled_contents = null;
                         $is_cacheable = false;
                     } elseif ( in_array( $status_code, WP2STATIC_REDIRECT_CODES ) ) {

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -187,16 +187,19 @@ class Crawler {
                         $page_hash = md5( (string) $status_code );
                     }
 
+                    $write_contents = true;
+
                     if ( $use_crawl_cache ) {
                         // if not already cached
                         if ( CrawlCache::getUrl( $root_relative_path, $page_hash ) ) {
                             $this->cache_hits++;
+                            $write_contents = false;
                         }
                     }
 
                     $this->crawled++;
 
-                    if ( $crawled_contents ) {
+                    if ( $crawled_contents && $write_contents) {
                         // do some magic here - naive: if URL ends in /, save to /index.html
                         // TODO: will need love for example, XML files
                         // check content type, serve .xml/rss, etc instead

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -156,10 +156,12 @@ class Crawler {
                     $crawled_contents = (string) $response->getBody();
                     $status_code = $response->getStatusCode();
 
+                    $is_cacheable = true;
                     if ( $status_code === 404 ) {
                         WsLog::l( '404 for URL ' . $root_relative_path );
                         CrawlCache::rmUrl( $root_relative_path );
                         $crawled_contents = null;
+                        $is_cacheable = false;
                     } elseif ( in_array( $status_code, WP2STATIC_REDIRECT_CODES ) ) {
                         $crawled_contents = null;
                     }
@@ -213,12 +215,14 @@ class Crawler {
                         }
                     }
 
-                    CrawlCache::addUrl(
-                        $root_relative_path,
-                        $page_hash,
-                        $status_code,
-                        $redirect_to
-                    );
+                    if( $is_cacheable ) {
+                        CrawlCache::addUrl(
+                            $root_relative_path,
+                            $page_hash,
+                            $status_code,
+                            $redirect_to
+                        );
+                    }
 
                     // incrementally log crawl progress
                     if ( $this->crawled % 300 === 0 ) {


### PR DESCRIPTION
Fix followings to improve crawling performance.

1. Skip writing content to reduce I/O write if cache exists.
2. Cache only if status code is not 404.
3. Delete crawl queue from database to prevent crawling urls again, which are not found.
4. Delete previously generated files under the directories both the crawled and the processed.
