### PR TITLE
Fix mysql syntax error by if exists

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -589,7 +589,7 @@ class Controller {
         $jobs = JobQueue::getProcessableJobs();
 
         foreach ( $jobs as $job ) {
-            $lock = 'wp2static_jobs.' . $job->job_type;
+            $lock = $wpdb->prefix . '.wp2static_jobs.' . $job->job_type;
             $query = "SELECT GET_LOCK('$lock', 30) AS lck";
             $locked = intval( $wpdb->get_row( $query )->lck );
             if ( ! $locked ) {

--- a/src/CoreOptions.php
+++ b/src/CoreOptions.php
@@ -42,8 +42,17 @@ class CoreOptions {
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         dbDelta( $sql );
 
-        $wpdb->query( "ALTER TABLE $table_name DROP COLUMN IF EXISTS description" );
-        $wpdb->query( "ALTER TABLE $table_name DROP COLUMN IF EXISTS label" );
+        $columns = array_keys( array_merge(...$wpdb->get_results(
+            sprintf("SELECT * FROM %s LIMIT 1", $table_name),
+            ARRAY_A
+        ) ) );
+
+        if ( in_array( 'description', $columns ) ) {
+            $wpdb->query( "ALTER TABLE $table_name DROP COLUMN description" );
+        }
+        if ( in_array( 'label', $columns ) ) {
+            $wpdb->query("ALTER TABLE $table_name DROP COLUMN label");
+        }
 
         Controller::ensureIndex(
             $table_name,

--- a/src/CoreOptions.php
+++ b/src/CoreOptions.php
@@ -42,16 +42,20 @@ class CoreOptions {
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         dbDelta( $sql );
 
-        $columns = array_keys( array_merge(...$wpdb->get_results(
-            sprintf("SELECT * FROM %s LIMIT 1", $table_name),
-            ARRAY_A
-        ) ) );
+        $columns = array_keys(
+            array_merge(
+                ...$wpdb->get_results(
+                    sprintf( 'SELECT * FROM %s LIMIT 1', $table_name ),
+                    ARRAY_A
+                )
+            )
+        );
 
         if ( in_array( 'description', $columns ) ) {
             $wpdb->query( "ALTER TABLE $table_name DROP COLUMN description" );
         }
         if ( in_array( 'label', $columns ) ) {
-            $wpdb->query("ALTER TABLE $table_name DROP COLUMN label");
+            $wpdb->query( "ALTER TABLE $table_name DROP COLUMN label" );
         }
 
         Controller::ensureIndex(

--- a/src/JobQueue.php
+++ b/src/JobQueue.php
@@ -252,7 +252,7 @@ class JobQueue {
 
         foreach ( $job_types as $type ) {
             try {
-                $lock = "wp2static_jobs.$type";
+                $lock = "{$wpdb->prefix}.wp2static_jobs.$type";
                 $query = "SELECT IS_FREE_LOCK('$lock') AS free";
                 $free = intval( $wpdb->get_row( $query )->free );
 


### PR DESCRIPTION
- WP2Static > Jobs を見た際に発生する `MySQL server version for the right syntax to use near 'IF EXISTS label' at line 1 for query ...` の不具合に対応
- Job Queue のマルチサイトの排他制御に対応